### PR TITLE
make some clarifications in the FAQ

### DIFF
--- a/content/getting-started/faq.md
+++ b/content/getting-started/faq.md
@@ -10,14 +10,18 @@ weight: 10
 ## What languages can I use with Hippo? Why isn't my favorite language supported?
 
 Hippo can serve any WebAssembly module that was compiled with support for [Web Application System Interface or WASI][wasi].
-Currently those languages are **AssemblyScript, C, Rust, and Swift**.
+We provide explicit support (in `yo-wasm`) for the following languages: **AssemblyScript, C, Rust, and Swift**.
+Other languages that can compile to `wasm32-wasi`, like Zig and Grain, will also work.
+You will just need to write your `HIPPOFACTS` file from scratch.
 
-Other languages such as C#, Python and JavaScript will hopefully support WASI in the future.
+Many other languages are working on their WebAssembly support. But a language must have
+support for the WASI specification before it can be used in Hippo.
 
 [wasi]: {{< relref "webassembly.md#webassembly-system-interface-wasi" >}}
 
-## What workloads are suited for WebAssembly?
+## What workloads are suited for Hippo?
 
-Considering the [benefits and limitations of WebAssembly][wasm], some workloads are better suited for running on WebAssembly than others. Microservices that interact over the network would be a prime candidate.
+Considering the [benefits and limitations of WebAssembly][wasm], some workloads are better suited for running on Hippo than others.
+Hippo is designed specifically for microservices and web applications.
 
 [wasm]: {{< relref "webassembly.md" >}}


### PR DESCRIPTION
I updated both questions in the FAQ.

The first one was a little misleading, in that there are more languages that compile to wasm32-wasi than the ones we support in yo-wasm.

The second one is a little concerning to me. We are presuming a normative answer to a question that is far more open ended. I tried to rewrite it to be limited to the scope of Hippo... because otherwise we are leaving out all the browser applications, the smart contract stuff, the plugin use case (e.g. Flight Simulator), ML stuff, etc. 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>