### PR TITLE
use docs.hippos.rocks as the domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://docs.deislabs.io/hippo/"
+baseURL = "https://docs.hippos.rocks"
 languageCode = "en-us"
 title = "Hippo"
 theme = "deislabs"
@@ -52,7 +52,7 @@ enableInlineShortcodes = true
 [[menu.main]]
 	name = "Home"
 	weight = 10
-	url = "https://deislabs.io/"
+	url = "https://hippos.rocks/"
 [[menu.main]]
 	name = "Docs"
 	weight = 20
@@ -61,7 +61,7 @@ enableInlineShortcodes = true
 # Uncomment to add your release versions here
 #[[params.versions]]
 #  version = "v0.1.0"
-#  url = "/hippo/"
+#  url = "/"
 
 
 # Theme Additional params
@@ -81,7 +81,7 @@ enableInlineShortcodes = true
   parent_url = "/"
   footer_logo = true
   footer_logo_img = "logo-with-text.png"
-  footer_url = "/hippo/"
+  footer_url = "/"
   ul_show = 2
 
 [params.ui.feedback]


### PR DESCRIPTION
This does two things:

- `hugo serve` from localhost now serves everything properly at http://localhost:1313 rather than http://localhost:1313/hippo (the latter broke image URLs)
- the base URL has been updated to hippos.rocks

This is more of a branding thing to keep Hippo separate from deislabs. A similar effort is being made with Krustlet now that it's going to the CNCF with https://docs.krustlet.dev/

closes #1

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>