### PR TITLE
link to netlify site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Hippo Website
 
-This repository generates the website at https://docs.deislabs.io/hippo/.
+This repository generates the website at <https://hippo-docs.netlify.app>.
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/3165223c-fa90-4905-b1db-73a170577073/deploy-status)](https://app.netlify.com/sites/hippo-docs/deploys)
 
 # Preview the Site
 
-Run `make preview` to preview the website.
-There are no dependencies other than Docker, and your web browser will open to the rendered site when ready, and then watch for changes.
+Run `hugo serve` to preview the website. Your web browser will open to the rendered site when ready, and then watch for changes.
+
+Run `make preview` if you want to run this as a Docker container.


### PR DESCRIPTION
Add link to site currently hosting the hippo docs. When we come to a decision whether to host it at docs.hippos.rocks (see #13) or docs.deislabs.io/hippo, then we can update the link.

I also changed the docs to mention running `hugo serve` locally. Most users are going to prefer running something quick and lightweight compared to Docker... As a former contributor to the Docker project, the dev loop with Docker nowadays is pretty bad.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>