### PR TITLE
update site url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://docs.deislabs.io/hippo/"
+baseURL = "https://docs.hippofactory.dev/"
 languageCode = "en-us"
 title = "Hippo"
 theme = "deislabs"


### PR DESCRIPTION
Changes the site url from `docs.deislabs.io/hippo` to `docs.hippofactory.dev`