### PR TITLE
update "boot hippo" guide

### DIFF
--- a/content/developers/developer-guide.md
+++ b/content/developers/developer-guide.md
@@ -50,36 +50,7 @@ $ export BINDLE_URL=https://bindle.deislabs.io/v1
 $ dotnet run
 ```
 
-Then, open https://localhost:5001 to view the browser. The
-default administrator username/password is 'admin' and 'Passw0rd!'.
-
-If you want to test the pre-seeded applications, open http://localhost:32768,
-http://localhost:32769, and http://localhost:32770. There you should find
-three applications all running and served by the local WAGI scheduler.
-
-```console
-$ curl localhost:32768
-Kia ora, world from 1.1.0!
-$ curl localhost:32769
-Hello, world from 1.0.0!
-$ curl localhost:32770
-Kia ora, world from 1.1.0!
-```
-
-Optionally, run the Rust test suite:
-
-```console
-$ cd ../hippo-client-rust
-$ cargo test
-```
-
-Open http://localhost:32770 again. You should notice that the application's
-version number changed.
-
-```console
-$ curl localhost:32770
-Bonjour from la belle version 1.1.1
-```
+Then, open https://localhost:5001 to view the browser.
 
 ## Testing
 
@@ -98,7 +69,7 @@ dotnet ef migrations add <name> --context SqliteDataContext --output-dir Migrati
 ASPNETCORE_ENVIRONMENT=Production dotnet ef migrations add <name> --context PostgresDataContext --output-dir Migrations/Postgres
 ```
 
-Sometimes manual fixups are required:
+Sometimes manual fix-ups are required:
 
 * **SQLite:** EF generates `"now()"` for database-generated columns. This doesn't exist. Change
   it to `"datetime('now')"` in both the migration and the designer.

--- a/content/intro/boot.md
+++ b/content/intro/boot.md
@@ -73,14 +73,26 @@ Hippo also includes a built in implementation of WAGI called [WAGI-dotnet](https
 
 ## Boot Hippo
 
-Download the [latest release](https://github.com/deislabs/hippo) of Hippo.
-Extract the project and move it somewhere sensible.
+This guide explains how to set up your environment for running Hippo from source.
 
-```console
-$ mv hippo /usr/local/hippo
-```
+Hippo is a .NET web application, built with the [Model-View-Controller](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc?view=aspnetcore-5.0&tabs=visual-studio) (MVC) approach.
 
-Restore Hippo's dependencies with
+The front-end uses the Bootstrap design framework, which (along with some other packages) is managed via [npm](https://www.npmjs.com/) and [gulp](https://gulpjs.com/).
+
+Clone the [repository on GitHub](https://github.com/deislabs/hippo).
+
+### System Requirements
+
+Install the following development tools:
+
+- [.NET 5](https://dot.net/)
+- [Node.js](https://nodejs.org/en/download/)
+- [npm](https://www.npmjs.com/get-npm)
+- [WAGI](https://github.com/deislabs/wagi)
+
+### Building
+
+To build the project, run:
 
 ```console
 $ dotnet restore


### PR DESCRIPTION
new plan is to release the source code, so the user will have to compile hippo from source to use it.

In the future this will be a released package using `dotnet publish`, but compiling from source is fine for now until we sort that out in another release.