### PR TITLE
docs(quickstart): Fix path for hippo .Net source (#43)

### DIFF
--- a/content/intro/running-locally.md
+++ b/content/intro/running-locally.md
@@ -91,7 +91,7 @@ To build the project, run:
 
 ```console
 $ git clone https://github.com/deislabs/hippo
-$ cd hippo/Hippo
+$ cd hippo/src/Hippo
 $ dotnet restore
 $ npm run build
 ```


### PR DESCRIPTION
This changes the path from hippo/Hippo to hippo/src/Hippo.
There appears to be only one place this needs to be changed.

Closes #43