### PR TITLE
Update .NET references to point to 6.0

### DIFF
--- a/content/developers/developer-guide.md
+++ b/content/developers/developer-guide.md
@@ -22,7 +22,7 @@ To get started either install the prerequisite tools locally or use a containeri
 
 Install the following development tools and then clone the repository.:
 
-- [.NET 5](https://dot.net/)
+- [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0)
 - [Node.js](https://nodejs.org/en/download/)
 - [npm](https://www.npmjs.com/get-npm)
 - [WAGI](https://github.com/deislabs/wagi)

--- a/content/intro/running-locally.md
+++ b/content/intro/running-locally.md
@@ -75,12 +75,12 @@ Install the following to compile Hippo from source:
 
 - [Git](https://git-scm.com/)
 - [Node.js](https://nodejs.org/)
-- [.NET 5](https://dot.net/)
+- [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0)
 
 ### Building
 
 Hippo is a .NET web application, built with the
-[Model-View-Controller](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc?view=aspnetcore-5.0&tabs=visual-studio)
+[Model-View-Controller](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc?view=aspnetcore-6.0&tabs=visual-studio)
 (MVC) approach.
 
 The front-end uses the Bootstrap design framework, which (along with some other


### PR DESCRIPTION
I wasn't able to build [hippo](https://github.com/deislabs/hippo) with my .NET 5.0.x version, so I assume use of .NET 6 as of https://github.com/deislabs/hippo/pull/287 is a hard requirement.  Hence, these docs updates.

Otherwise, if building hippo w/ .NET < 6.0 is still possible, happy to close and/or add different doc updates.