### PR TITLE
cargo install needs path

### DIFF
--- a/content/intro/install-hippo.md
+++ b/content/intro/install-hippo.md
@@ -64,7 +64,7 @@ $ cd hippo-cli
 Then, compile and install Hippo:
 
 ```console
-$ cargo install
+$ cargo install --path .
 ```
 
 ## Verify the Installation


### PR DESCRIPTION
Hi team,

I was walking through the docs, but I don't seem to be able to run `cargo install` as indicated:

```sh
$ git clone https://github.com/deislabs/hippo-cli
Cloning into 'hippo-cli'...
remote: Enumerating objects: 543, done.
remote: Counting objects: 100% (378/378), done.
remote: Compressing objects: 100% (247/247), done.
remote: Total 543 (delta 236), reused 211 (delta 125), pack-reused 165
Receiving objects: 100% (543/543), 200.43 KiB | 2.15 MiB/s, done.
Resolving deltas: 100% (277/277), done.

$ cd hippo-cli

$ cargo install
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
```

I reran `rustup` to make sure I was using an up to date version of cargo but it yielded the same result with:

```sh
# cargo version
cargo 1.59.0 (49d8809dc 2022-02-10)
```

Using a relative path seems to provide the desired results:

```sh
$ cargo install --path .
  Installing hippo v0.9.0 (/Users/ryan/source/rust/hippo-cli)
    Updating crates.io index
....
   Installed package `hippo v0.9.0 (/Users/ryan/source/rust/hippo-cli)` (executable `hippo`)
```